### PR TITLE
github workflow for prod when pushed to main

### DIFF
--- a/.github/workflows/deploy_frontend_prod.yaml
+++ b/.github/workflows/deploy_frontend_prod.yaml
@@ -1,0 +1,47 @@
+name: Deploy lkpc-frontend to S3
+
+# Triggers on push to main and dev branches
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  S3PackageUpload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git clone the repository
+        uses: actions/checkout@v4
+
+      # Set up Node.js environment
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+
+      # Install dependencies
+      - name: Install dependencies
+        run: npm install
+
+      # Build the app
+      - name: Build the app
+        run: npm run build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::559050210691:role/GithubActionRole
+          session-name: "github-to-s3"
+          aws-region: us-east-2
+
+      - name: Deploy to S3
+        run: |
+          aws s3 sync out/ s3://lkpc-hosting-prod --delete
+
+      - name: Invalidate Cloudfront cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id "E16EK7ECFKG5QL" --paths "/*"


### PR DESCRIPTION
Closes #33

## Overview 
- Adds the same github workflow for the prod(main) as the dev
- Uses `npm run build` to create `out` folder
- When pushed to main branch, it is uploaded to S3 bucket, used by CloudFront of prod on aws