### PR TITLE
Fixed the event modal bug on portrait view

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -23,7 +23,7 @@ const Modal: React.FC<ModalProps> = ({ handleModalClose, eventTitle, startDate, 
 
     return (
         <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-30">
-            <div className="bg-white max-h-[50%] w-11/12 sm:w-1/2 lg:w-1/3 p-1 rounded-xl shadow-xl relative" ref={modalRef}>
+            <div className="bg-white max-h-[100%] w-11/12 sm:w-1/2 lg:w-1/3 p-1 rounded-xl shadow-xl relative" ref={modalRef}>
                 <div className="relative items-end max-h-[90vh] bg-white rounded-xl z-10 space-y-2 p-4 overflow-hidden">
                     <Image
                         onClick={handleModalClose}


### PR DESCRIPTION
Closes #95
## Overview
it was limited to only being 50% height MAX of the entire page meaning that the outside modal part couldn't be bigger than 50% of the height of the screen 